### PR TITLE
Support for x-jms-topic and exchange to exchange binding

### DIFF
--- a/Public/Add-RabbitMQExchange.ps1
+++ b/Public/Add-RabbitMQExchange.ps1
@@ -69,7 +69,7 @@ function Add-RabbitMQExchange
 
         # Type of the Exchange to create.
         [parameter(Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
-        [ValidateSet("topic", "fanout", "direct", "headers")]
+        [ValidateSet("topic", "fanout", "direct", "headers", "x-jms-topic")]
         [string]$Type,
 
         # Determines whether the exchange should be Durable.

--- a/RabbitMQTools.psd1
+++ b/RabbitMQTools.psd1
@@ -72,6 +72,7 @@ FormatsToProcess = @('RabbitMqTools.Format.Ps1xml')
 # Functions to export from this module
 FunctionsToExport = @(
     'Add-RabbitMQExchange',
+    'Add-RabbitMQExchangeBinding',
     'Add-RabbitMQMessage',
     'Add-RabbitMQPermission',
     'Add-RabbitMQQueue',

--- a/RabbitMQTools.psm1
+++ b/RabbitMQTools.psm1
@@ -41,6 +41,7 @@ New-Alias -Name rrvh -value Remove-RabbitMQVirtualHost -Description "Removes Rab
 New-Alias -Name delvhost -value Remove-RabbitMQVirtualHost -Description "Removes RabbitMQ's Virutal Hosts"
 
 New-Alias -Name gre -value Get-RabbitMQExchange -Description "Gets RabbitMQ's Exchages"
+New-Alias -Name addexchangebinding -value Add-RabbitMQExchangeBinding -Description "Adds bindings between RabbitMQ exchanges"
 
 New-Alias -Name grq -value Get-RabbitMQQueue -Description "Gets RabbitMQ's Queues"
 New-Alias -Name getqueue -value Get-RabbitMQQueue -Description "Gets RabbitMQ's Queues"
@@ -49,7 +50,7 @@ New-Alias -Name addqueue -value Add-RabbitMQQueue -Description "Adds RabbitMQ's 
 New-Alias -Name rrq -value Remove-RabbitMQQueue -Description "Removes RabbitMQ's Queues"
 New-Alias -Name delqueue -value Remove-RabbitMQQueue -Description "Removes RabbitMQ's Queues"
 New-Alias -Name getqueuebinding -value Get-RabbitMQQueueBinding -Description "Gets bindings for RabbitMQ Queues"
-New-Alias -Name addqueuebinding -value Add-RabbitMQQueueBinding -Description "Adds bindings betwen RabbitMQ exchange and queue"
+New-Alias -Name addqueuebinding -value Add-RabbitMQQueueBinding -Description "Adds bindings between RabbitMQ exchange and queue"
 
 New-Alias -Name getmessage -value Get-RabbitMQMessage -Description "Gets messages from RabbitMQ queue"
 


### PR DESCRIPTION
The X-JMS-Topic type is an exchange available through the rabbitmq_jms_topic_exchange plugin. 
We use this quite extensively for its SQL style filtering of messages, so I made some minor mods to support it.

Also I noticed there was no cmdlet to use the exchange to exchange binding feature in the web API.

Changes made:
Added support for X-JMS-TOPIC header type used for JMS SQL filtering. I made some modifications to the Powershell scripting to support it. 
Added a cmdlet to add an exchange to exchange binding, very similar to the exchange to queue binding.

