### PR TITLE
Encode spaces in names as '%20' intead of '+'

### DIFF
--- a/Public/Add-RabbitMQExchange.ps1
+++ b/Public/Add-RabbitMQExchange.ps1
@@ -124,7 +124,7 @@ function Add-RabbitMQExchange
 
             foreach($n in $Name)
             {
-                $url = Join-Parts $BaseUri "/api/exchanges/$([System.Web.HttpUtility]::UrlEncode($VirtualHost))/$([System.Web.HttpUtility]::UrlEncode($n))"
+                $url = Join-Parts $BaseUri "/api/exchanges/$([System.Web.HttpUtility]::UrlEncode($VirtualHost))/$([System.Uri]::EscapeDataString($n))"
                 Write-Verbose "Invoking REST API: $url"
         
                 $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Put -ContentType "application/json" -Body $bodyJson

--- a/Public/Add-RabbitMQExchangeBinding.ps1
+++ b/Public/Add-RabbitMQExchangeBinding.ps1
@@ -91,7 +91,7 @@ function Add-RabbitMQExchangeBinding
         {
             foreach($n in $Name)
             {
-                $url = Join-Parts $BaseUri "/api/bindings/$([System.Web.HttpUtility]::UrlEncode($VirtualHost))/e/$([System.Web.HttpUtility]::UrlEncode($ExchangeName))/e/$([System.Web.HttpUtility]::UrlEncode($Name))"
+                $url = Join-Parts $BaseUri "/api/bindings/$([System.Web.HttpUtility]::UrlEncode($VirtualHost))/e/$([System.Uri]::EscapeDataString($ExchangeName))/e/$([System.Uri]::EscapeDataString($Name))"
                 Write-Verbose "Invoking REST API: $url"
 
                 $body = @{

--- a/Public/Add-RabbitMQMessage.ps1
+++ b/Public/Add-RabbitMQMessage.ps1
@@ -80,7 +80,7 @@ function Add-RabbitMQMessage
     {
         if ($pscmdlet.ShouldProcess("server: $BaseUri/$VirtualHost", "Publish message to exchange $ExchangeName with routing key $RoutingKey"))
         {
-            $url = Join-Parts $BaseUri "/api/exchanges/$([System.Web.HttpUtility]::UrlEncode($VirtualHost))/$([System.Web.HttpUtility]::UrlEncode($ExchangeName))/publish"
+            $url = Join-Parts $BaseUri "/api/exchanges/$([System.Web.HttpUtility]::UrlEncode($VirtualHost))/$([System.Uri]::EscapeDataString($ExchangeName))/publish"
             Write-Verbose "Invoking REST API: $url"
 
             $body = @{

--- a/Public/Add-RabbitMQQueue.ps1
+++ b/Public/Add-RabbitMQQueue.ps1
@@ -103,7 +103,7 @@ function Add-RabbitMQQueue
         {
             foreach($n in $Name)
             {
-                $url = Join-Parts $BaseUri "/api/queues/$([System.Web.HttpUtility]::UrlEncode($VirtualHost))/$([System.Web.HttpUtility]::UrlEncode($n))"
+                $url = Join-Parts $BaseUri "/api/queues/$([System.Web.HttpUtility]::UrlEncode($VirtualHost))/$([System.Uri]::EscapeDataString($n))"
                 Write-Verbose "Invoking REST API: $url"
 
                 $body = @{}

--- a/Public/Add-RabbitMQQueueBinding.ps1
+++ b/Public/Add-RabbitMQQueueBinding.ps1
@@ -91,7 +91,7 @@ function Add-RabbitMQQueueBinding
         {
             foreach($n in $Name)
             {
-                $url = Join-Parts $BaseUri "/api/bindings/$([System.Web.HttpUtility]::UrlEncode($VirtualHost))/e/$([System.Web.HttpUtility]::UrlEncode($ExchangeName))/q/$([System.Web.HttpUtility]::UrlEncode($Name))"
+                $url = Join-Parts $BaseUri "/api/bindings/$([System.Web.HttpUtility]::UrlEncode($VirtualHost))/e/$([System.Uri]::EscapeDataString($ExchangeName))/q/$([System.Uri]::EscapeDataString($Name))"
                 Write-Verbose "Invoking REST API: $url"
 
                 $body = @{

--- a/Public/Clear-RabbitMQQueue.ps1
+++ b/Public/Clear-RabbitMQQueue.ps1
@@ -58,7 +58,7 @@ function Clear-RabbitMQQueue
     {
         if ($pscmdlet.ShouldProcess("server: $BaseUri/$VirtualHost", "purge queue $Name"))
         {
-            $url = Join-Parts $BaseUri "/api/queues/$([System.Web.HttpUtility]::UrlEncode($VirtualHost))/$([System.Web.HttpUtility]::UrlEncode($Name))/contents"
+            $url = Join-Parts $BaseUri "/api/queues/$([System.Web.HttpUtility]::UrlEncode($VirtualHost))/$([System.Uri]::EscapeDataString($Name))/contents"
             Write-Verbose "Invoking REST API: $url"
 
             $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Delete

--- a/Public/Get-RabbitMQMessage.ps1
+++ b/Public/Get-RabbitMQMessage.ps1
@@ -113,7 +113,7 @@ function Get-RabbitMQMessage
         if ([bool]$Remove) { $s = "Messages will be removed from the queue." } else {$s = "Messages will be requeued."}
         if ($pscmdlet.ShouldProcess("server: $BaseUri/$VirtualHost", "Get $Count message(s) from queue $Name. $s"))
         {
-            $url = Join-Parts $BaseUri "/api/queues/$([System.Web.HttpUtility]::UrlEncode($VirtualHost))/$([System.Web.HttpUtility]::UrlEncode($Name))/get"
+            $url = Join-Parts $BaseUri "/api/queues/$([System.Web.HttpUtility]::UrlEncode($VirtualHost))/$([System.Uri]::EscapeDataString($Name))/get"
             Write-Verbose "Invoking REST API: $url"
 
             $body = @{

--- a/Public/Get-RabbitMQQueueBinding.ps1
+++ b/Public/Get-RabbitMQQueueBinding.ps1
@@ -91,7 +91,7 @@ function Get-RabbitMQQueueBinding
         {
             foreach ($n in $Name)
             {
-                $result = GetItemsFromRabbitMQApi -BaseUri $BaseUri $Credentials "queues/$([System.Web.HttpUtility]::UrlEncode($VirtualHost))/$([System.Web.HttpUtility]::UrlEncode($n))/bindings"
+                $result = GetItemsFromRabbitMQApi -BaseUri $BaseUri $Credentials "queues/$([System.Web.HttpUtility]::UrlEncode($VirtualHost))/$([System.Uri]::EscapeDataString($n))/bindings"
 
                 $result | Add-Member -NotePropertyName "HostName" -NotePropertyValue $BaseUri
 

--- a/Public/Remove-RabbitMQExchange.ps1
+++ b/Public/Remove-RabbitMQExchange.ps1
@@ -88,7 +88,7 @@ function Remove-RabbitMQExchange
         {
             foreach($n in $Name)
             {
-                $url = Join-Parts $BaseUri "/api/exchanges/$([System.Web.HttpUtility]::UrlEncode($VirtualHost))/$([System.Web.HttpUtility]::UrlEncode($n))"
+                $url = Join-Parts $BaseUri "/api/exchanges/$([System.Web.HttpUtility]::UrlEncode($VirtualHost))/$([System.Uri]::EscapeDataString($n))"
         
                 $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Delete
 

--- a/Public/Remove-RabbitMQQueue.ps1
+++ b/Public/Remove-RabbitMQQueue.ps1
@@ -88,7 +88,7 @@ function Remove-RabbitMQQueue
         {
             foreach($n in $Name)
             {
-                $url = Join-Parts $BaseUri "/api/queues/$([System.Web.HttpUtility]::UrlEncode($VirtualHost))/$([System.Web.HttpUtility]::UrlEncode($n))"
+                $url = Join-Parts $BaseUri "/api/queues/$([System.Web.HttpUtility]::UrlEncode($VirtualHost))/$([System.Uri]::EscapeDataString($n))"
                 Write-Verbose "Invoking REST API: $url"
         
                 $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Delete


### PR DESCRIPTION
If your queue (or exchange) name contains some space chars, any operations you want to do with it will end up with an error like this:
```
Invoke-RestMethod : {"error":"Object Not Found","reason":"Not Found"}
At C:\Program Files\WindowsPowerShell\Modules\RabbitMQTools\1.5\Public\Remove-RabbitMQQueue.ps1:94 char:17
+ ...             $result = Invoke-RestMethod $url -Credential $Credentials ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (System.Net.HttpWebRequest:HttpWebRequest) [Invoke-RestMethod], WebExc
   eption
    + FullyQualifiedErrorId : WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand
Invoke-RestMethod : {"error":"Object Not Found","reason":"Not Found"}
At C:\Program Files\WindowsPowerShell\Modules\RabbitMQTools\1.5\Public\Remove-RabbitMQQueue.ps1:94 char:17
+ ...             $result = Invoke-RestMethod $url -Credential $Credentials ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (System.Net.HttpWebRequest:HttpWebRequest) [Invoke-RestMethod], WebExc
   eption
    + FullyQualifiedErrorId : WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand
```

This caused by incorrect encoding url:
RMQ expects smth like:
http://localhost:15672/api/queues/%2F/API%2C%20API

But actual url generated by script is:
http://localhost:15672/api/queues/%2f/API%2c+API