### PR TITLE
Added the option SkipCertificateCheck for self-signed certificates

### DIFF
--- a/Private/GetItemsFromRabbitMQApi.ps1
+++ b/Private/GetItemsFromRabbitMQApi.ps1
@@ -9,18 +9,22 @@
 
         [parameter(Mandatory=$true, Position = 1)]
         [PSCredential]$cred = $defaultCredentials,
-        
+
         [parameter(Mandatory=$true, Position = 2)]
         [string]$function,
 
-        [int]$Port = 15672
+        [int]$Port = 15672,
+
+        # Disable certificate check
+        [Parameter(Mandatory=$false)]
+        [switch]${SkipCertificateCheck}
     )
 
     Add-Type -AssemblyName System.Web
     #Add-Type -AssemblyName System.Net
-                
+
     $url = Join-Parts $BaseUri "/api/$function"
     Write-Verbose "Invoking REST API: $url"
-    
-    return Invoke-RestMethod $url -Credential $cred -DisableKeepAlive -AllowEscapedDotsAndSlashes
+
+    return Invoke-RestMethod $url -Credential $cred -SkipCertificateCheck:$SkipCertificateCheck -DisableKeepAlive -AllowEscapedDotsAndSlashes
 }

--- a/Private/Invoke-RestMethod.ps1
+++ b/Private/Invoke-RestMethod.ps1
@@ -1,6 +1,6 @@
 ﻿<#
     .NOTES
-    Invoke-RestMethod parameter have changed somewhat in powershell core. 
+    Invoke-RestMethod parameter have changed somewhat in powershell core.
     See https://get-powershellblog.blogspot.co.uk/2017/11/powershell-core-web-cmdlets-in-depth.html#L08
 #>
 
@@ -83,7 +83,10 @@ function Invoke-RestMethod
         ${PassThru},
 
         [switch]
-        ${AllowEscapedDotsAndSlashes})
+        ${AllowEscapedDotsAndSlashes},
+
+        [switch]
+        ${SkipCertificateCheck})
 
     begin
     {
@@ -93,7 +96,7 @@ function Invoke-RestMethod
             {
                 $PSBoundParameters['OutBuffer'] = 1
             }
-            
+
             $wrappedCmd = $ExecutionContext.InvokeCommand.GetCommand('Microsoft.PowerShell.Utility\Invoke-RestMethod', [System.Management.Automation.CommandTypes]::Cmdlet)
 
             # check whether need to disable UnEscapingDotsAndSlases on UriParser
@@ -101,7 +104,7 @@ function Invoke-RestMethod
             $requiresDisableUnEscapingDotsAndSlashes = ($AllowEscapedDotsAndSlashes -and $Uri.OriginalString -match '%2f')
             # remove additional proxy parameter to prevent original function from failing
             if($PSBoundParameters['AllowEscapedDotsAndSlashes']) { $null = $PSBoundParameters.Remove('AllowEscapedDotsAndSlashes') }
-            
+
             #Invoke-RestMethod for Powershell Core
             If ($isPowershellCore) {
                 #For core you must explicitly define the Authentication method.
@@ -118,7 +121,7 @@ function Invoke-RestMethod
                         $PSBoundParameters['Headers'] = @{ 'content-length' = 0 }
                     }
                 }
-                
+
                 #It seems that sometimes errors occur if you don't yield a short time.
                 Start-Sleep -Milliseconds 100
                 $scriptCmd = {& $wrappedCmd @PSBoundParameters }
@@ -139,7 +142,7 @@ function Invoke-RestMethod
             }
 
             $steppablePipeline.Process($_)
-        } 
+        }
         finally {
             # Restore UnEscapingDotsAndSlashes on UriParser when necessary
             if ($requiresDisableUnEscapingDotsAndSlashes -and -not $isPowershellCore) {

--- a/Public/Add-RabbitMQExchange.ps1
+++ b/Public/Add-RabbitMQExchange.ps1
@@ -48,7 +48,7 @@
    $a | Add-RabbitMQExchange
 
    Above example shows how to pipe parameters for creating new exchanges.
-   
+
    In the above example three new exchanges will be created with different parameters.
 
 .INPUTS
@@ -75,11 +75,11 @@ function Add-RabbitMQExchange
         # Determines whether the exchange should be Durable.
         [parameter(ValueFromPipelineByPropertyName=$true)]
         [switch]$Durable,
-        
+
         # Determines whether the exchange will be deleted once all queues have finished using it.
         [parameter(ValueFromPipelineByPropertyName=$true)]
         [switch]$AutoDelete,
-        
+
         # Determines whether the exchange should be Internal.
         [parameter(ValueFromPipelineByPropertyName=$true)]
         [switch]$Internal,
@@ -101,7 +101,11 @@ function Add-RabbitMQExchange
 
         # Credentials to use when logging to RabbitMQ server.
         [Parameter(Mandatory=$false)]
-        [PSCredential]$Credentials = $defaultCredentials
+        [PSCredential]$Credentials = $defaultCredentials,
+
+        # Disable certificate check
+        [Parameter(Mandatory=$false)]
+        [switch]${SkipCertificateCheck}
     )
 
     Begin
@@ -110,7 +114,7 @@ function Add-RabbitMQExchange
     Process
     {
         if ($pscmdlet.ShouldProcess("server: $BaseUri, vhost: $VirtualHost", "Add exchange(s): $(NamesToString $Name '(all)')")) {
-            
+
             $body = @{
                 type = "$Type"
             }
@@ -126,8 +130,8 @@ function Add-RabbitMQExchange
             {
                 $url = Join-Parts $BaseUri "/api/exchanges/$([System.Web.HttpUtility]::UrlEncode($VirtualHost))/$([System.Web.HttpUtility]::UrlEncode($n))"
                 Write-Verbose "Invoking REST API: $url"
-        
-                $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Put -ContentType "application/json" -Body $bodyJson
+
+                $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -SkipCertificateCheck:$SkipCertificateCheck -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Put -ContentType "application/json" -Body $bodyJson
 
                 Write-Verbose "Created Exchange $n on server $BaseUri, Virtual Host $VirtualHost"
                 $cnt++

--- a/Public/Add-RabbitMQExchangeBinding.ps1
+++ b/Public/Add-RabbitMQExchangeBinding.ps1
@@ -71,14 +71,18 @@ function Add-RabbitMQExchangeBinding
         [parameter(ValueFromPipelineByPropertyName=$true, Position=4)]
         [Alias("HostName", "hn", "cn")]
         [string]$BaseUri = $defaultComputerName,
-        
+
   		# Switch to unescape web characters (For x-jms-topic).
         [parameter(Mandatory=$false, ValueFromPipelineByPropertyName=$true, Position=5)]
         [switch]$DontEscape,
 
         # Credentials to use when logging to RabbitMQ server.
         [Parameter(Mandatory=$false)]
-        [PSCredential]$Credentials = $defaultCredentials 
+        [PSCredential]$Credentials = $defaultCredentials,
+
+        # Disable certificate check
+        [Parameter(Mandatory=$false)]
+        [switch]${SkipCertificateCheck}
     )
 
     Begin
@@ -108,7 +112,7 @@ function Add-RabbitMQExchangeBinding
 				{
 					$bodyJson = $body | ConvertTo-Json -Depth 3 -Compress
 				}
-				$result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Post -ContentType "application/json" -Body $bodyJson
+				$result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -SkipCertificateCheck:$SkipCertificateCheck -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Post -ContentType "application/json" -Body $bodyJson
 
                 Write-Verbose "Bound exchange $ExchangeName to exchange $Name $n on $BaseUri/$VirtualHost"
                 $cnt++

--- a/Public/Add-RabbitMQMessage.ps1
+++ b/Public/Add-RabbitMQMessage.ps1
@@ -29,7 +29,7 @@
 .INPUTS
 
 .OUTPUTS
-   By default, the cmdlet returns list of RabbitMQ.QueueMessage objects which describe connections. 
+   By default, the cmdlet returns list of RabbitMQ.QueueMessage objects which describe connections.
 
 .LINK
     https://www.rabbitmq.com/management.html - information about RabbitMQ management plugin.
@@ -53,7 +53,7 @@ function Add-RabbitMQMessage
         [parameter(Mandatory=$true, ValueFromPipelineByPropertyName=$true, Position=2)]
         [Alias("rk")]
         [string]$RoutingKey,
-        
+
         # Massage's payload
         [parameter(Mandatory=$true, ValueFromPipelineByPropertyName=$true, Position=3)]
         [string]$Payload,
@@ -69,7 +69,11 @@ function Add-RabbitMQMessage
 
         # Credentials to use when logging to RabbitMQ server.
         [Parameter(Mandatory=$false)]
-        [PSCredential]$Credentials = $defaultCredentials
+        [PSCredential]$Credentials = $defaultCredentials,
+
+        # Disable certificate check
+        [Parameter(Mandatory=$false)]
+        [switch]${SkipCertificateCheck}
     )
 
     Begin
@@ -92,12 +96,12 @@ function Add-RabbitMQMessage
 
             $bodyJson = $body | ConvertTo-Json
 
-            
+
             $retryCounter = 0
 
             while ($retryCounter -lt 3)
             {
-                $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Post -ContentType "application/json" -Body $bodyJson
+                $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -SkipCertificateCheck:$SkipCertificateCheck -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Post -ContentType "application/json" -Body $bodyJson
 
                 if ($result.routed -ne $true)
                 {

--- a/Public/Add-RabbitMQPermission.ps1
+++ b/Public/Add-RabbitMQPermission.ps1
@@ -60,14 +60,18 @@ function Add-RabbitMQPermission
 
         # Credentials to use when logging to RabbitMQ server.
         [Parameter(Mandatory=$false)]
-        [PSCredential]$Credentials = $defaultCredentials
+        [PSCredential]$Credentials = $defaultCredentials,
+
+        # Disable certificate check
+        [Parameter(Mandatory=$false)]
+        [switch]${SkipCertificateCheck}
     )
 
     Begin
-    {      
-        $p = Get-RabbitMQPermission -BaseUri $BaseUri -Credentials $Credentials -VirtualHost $VirtualHost -User $User
+    {
+        $p = Get-RabbitMQPermission -BaseUri $BaseUri -Credentials $Credentials -SkipCertificateCheck:$SkipCertificateCheck -VirtualHost $VirtualHost -User $User
         if ($p) { throw "Permissions to virtual host $VirtualHost for user $User already exist. To change permissions use Set-RabbitMQPermission cmdlet." }
-        
+
         $cnt = 0
     }
     Process
@@ -78,9 +82,9 @@ function Add-RabbitMQPermission
             $body = @{
                 'configure' = $Configure
                 'read' = $Read
-                'write' = $Write                
+                'write' = $Write
             } | ConvertTo-Json
-            $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Put -ContentType "application/json" -Body $body
+            $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -SkipCertificateCheck:$SkipCertificateCheck -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Put -ContentType "application/json" -Body $body
 
             Write-Verbose "Created permission to $VirtualHost for $User : $Configure, $Read, $Write"
             $cnt++

--- a/Public/Add-RabbitMQQueue.ps1
+++ b/Public/Add-RabbitMQQueue.ps1
@@ -74,7 +74,7 @@ function Add-RabbitMQQueue
         # Determines whether the queue should be durable.
         [parameter(ValueFromPipelineByPropertyName=$true)]
         [switch]$Durable = $false,
-        
+
         # Determines whether the queue should be deleted automatically after all consumers have finished using it.
         [parameter(ValueFromPipelineByPropertyName=$true)]
         [switch]$AutoDelete = $false,
@@ -90,7 +90,11 @@ function Add-RabbitMQQueue
 
         # Optional arguments
         [Parameter(Mandatory=$false, ValueFromPipelineByPropertyName=$true)]
-        [hashtable]$Arguments
+        [hashtable]$Arguments,
+
+        # Disable certificate check
+        [Parameter(Mandatory=$false)]
+        [switch]${SkipCertificateCheck}
     )
 
     Begin
@@ -112,7 +116,7 @@ function Add-RabbitMQQueue
                 if ($Arguments -ne $null -and $Arguments.Count -gt 0) { $body.Add("arguments", $Arguments) }
 
                 $bodyJson = $body | ConvertTo-Json
-                $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Put -ContentType "application/json" -Body $bodyJson
+                $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -SkipCertificateCheck:$SkipCertificateCheck -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Put -ContentType "application/json" -Body $bodyJson
 
                 Write-Verbose "Created Queue $n on $BaseUri/$VirtualHost"
                 $cnt++

--- a/Public/Add-RabbitMQQueueBinding.ps1
+++ b/Public/Add-RabbitMQQueueBinding.ps1
@@ -71,14 +71,18 @@ function Add-RabbitMQQueueBinding
         [parameter(ValueFromPipelineByPropertyName=$true, Position=4)]
         [Alias("HostName", "hn", "cn")]
         [string]$BaseUri = $defaultComputerName,
-        
+
   		# Switch to unescape web characters (For x-jms-topic).
         [parameter(Mandatory=$false, ValueFromPipelineByPropertyName=$true, Position=5)]
         [switch]$DontEscape,
 
         # Credentials to use when logging to RabbitMQ server.
         [Parameter(Mandatory=$false)]
-        [PSCredential]$Credentials = $defaultCredentials 
+        [PSCredential]$Credentials = $defaultCredentials,
+
+        # Disable certificate check
+        [Parameter(Mandatory=$false)]
+        [switch]${SkipCertificateCheck}
     )
 
     Begin
@@ -108,7 +112,7 @@ function Add-RabbitMQQueueBinding
 				{
 					$bodyJson = $body | ConvertTo-Json -Depth 3 -Compress
 				}
-                $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Post -ContentType "application/json" -Body $bodyJson
+                $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -SkipCertificateCheck:$SkipCertificateCheck -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Post -ContentType "application/json" -Body $bodyJson
 
                 Write-Verbose "Bound exchange $ExchangeName to queue $Name $n on $BaseUri/$VirtualHost"
                 $cnt++

--- a/Public/Add-RabbitMQUser.ps1
+++ b/Public/Add-RabbitMQUser.ps1
@@ -53,7 +53,11 @@ function Add-RabbitMQUser
 
         # Credentials to use when logging to RabbitMQ server.
         [Parameter(Mandatory=$false)]
-        [PSCredential]$Credentials = $defaultCredentials
+        [PSCredential]$Credentials = $defaultCredentials,
+
+        # Disable certificate check
+        [Parameter(Mandatory=$false)]
+        [switch]${SkipCertificateCheck}
     )
 
     Begin
@@ -69,7 +73,7 @@ function Add-RabbitMQUser
                 'password' = $NewPassword
                 'tags' = $Tag -join ','
             } | ConvertTo-Json
-            $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Put -ContentType "application/json" -Body $body
+            $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -SkipCertificateCheck:$SkipCertificateCheck -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Put -ContentType "application/json" -Body $body
 
             Write-Verbose "Created user $User with tags $Tag"
             $cnt++

--- a/Public/Add-RabbitMQVirtualHost.ps1
+++ b/Public/Add-RabbitMQVirtualHost.ps1
@@ -44,7 +44,7 @@
    $a | Add-RabbitMQVirtualHost
 
    Above example shows how to pipe both Virtual Host name and Computer Name to specify server on which the Virtual Host should be created.
-   
+
    In the above example two new Virtual Hosts named "vh1" and "vh1" will be created in RabbitMQ local server, and one Virtual Host named "vh3" will be created on the server 127.0.0.1.
 
 .INPUTS
@@ -70,7 +70,11 @@ function Add-RabbitMQVirtualHost
 
         # Credentials to use when logging to RabbitMQ server.
         [Parameter(Mandatory=$false)]
-        [PSCredential]$Credentials
+        [PSCredential]$Credentials,
+
+        # Disable certificate check
+        [Parameter(Mandatory=$false)]
+        [switch]${SkipCertificateCheck}
     )
 
     Begin
@@ -80,9 +84,9 @@ function Add-RabbitMQVirtualHost
     Process
     {
         if (-not $pscmdlet.ShouldProcess("server: $BaseUri", "Add vhost(s): $(NamesToString $Name '(all)')")) {
-            foreach ($qn in $Name) 
-            { 
-                Write "Creating new Virtual Host $qn on server $BaseUri" 
+            foreach ($qn in $Name)
+            {
+                Write "Creating new Virtual Host $qn on server $BaseUri"
                 $cnt++
             }
 
@@ -92,7 +96,7 @@ function Add-RabbitMQVirtualHost
         foreach($n in $Name)
         {
             $url = Join-Parts $BaseUri "/api/vhosts/$([System.Web.HttpUtility]::UrlEncode($n))"
-            $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Put -ContentType "application/json"
+            $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -SkipCertificateCheck:$SkipCertificateCheck -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Put -ContentType "application/json"
 
             Write-Verbose "Created Virtual Host $n on server $BaseUri"
             $cnt++

--- a/Public/Clear-RabbitMQQueue.ps1
+++ b/Public/Clear-RabbitMQQueue.ps1
@@ -40,7 +40,7 @@ function Clear-RabbitMQQueue
         [parameter(Mandatory=$true, ValueFromPipelineByPropertyName=$true, Position=1)]
         [Alias("qn", "QueueName")]
         [string]$Name,
-        
+
         # Name of the computer hosting RabbitMQ server. Defalut value is localhost.
         [parameter(ValueFromPipelineByPropertyName=$true, Position=2)]
         [Alias("cn", "HostName")]
@@ -48,7 +48,11 @@ function Clear-RabbitMQQueue
 
         # Credentials to use when logging to RabbitMQ server.
         [Parameter(Mandatory=$false)]
-        [PSCredential]$Credentials = $defaultCredentials
+        [PSCredential]$Credentials = $defaultCredentials,
+
+        # Disable certificate check
+        [Parameter(Mandatory=$false)]
+        [switch]${SkipCertificateCheck}
     )
 
     Begin
@@ -61,7 +65,7 @@ function Clear-RabbitMQQueue
             $url = Join-Parts $BaseUri "/api/queues/$([System.Web.HttpUtility]::UrlEncode($VirtualHost))/$([System.Web.HttpUtility]::UrlEncode($Name))/contents"
             Write-Verbose "Invoking REST API: $url"
 
-            $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Delete
+            $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -SkipCertificateCheck:$SkipCertificateCheck -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Delete
         }
     }
     End

--- a/Public/Get-RabbitMQChannel.ps1
+++ b/Public/Get-RabbitMQChannel.ps1
@@ -56,7 +56,7 @@ function Get-RabbitMQChannel
         [parameter(ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
         [Alias("Channel", "ChannelName")]
         [string[]]$Name = "",
-               
+
         # Name of the computer hosting RabbitMQ server. Defalut value is localhost.
         [parameter(ValueFromPipelineByPropertyName=$true)]
         [Alias("HostName", "hn", "cn")]
@@ -69,7 +69,11 @@ function Get-RabbitMQChannel
 
         # Credentials to use when logging to RabbitMQ server.
         [Parameter(Mandatory=$false)]
-        [PSCredential]$Credentials = $defaultCredentials
+        [PSCredential]$Credentials = $defaultCredentials,
+
+        # Disable certificate check
+        [Parameter(Mandatory=$false)]
+        [switch]${SkipCertificateCheck}
     )
 
     Begin
@@ -79,8 +83,8 @@ function Get-RabbitMQChannel
     {
         if ($pscmdlet.ShouldProcess("server $BaseURI", "Get node(s): $(NamesToString $Name '(all)')"))
         {
-            $result = GetItemsFromRabbitMQApi -BaseUri $BaseURI $Credentials "channels"
-            
+            $result = GetItemsFromRabbitMQApi -BaseUri $BaseURI $Credentials "channels" -SkipCertificateCheck:$SkipCertificateCheck
+
             $result = ApplyFilter $result 'name' $Name
             if ($VirtualHost) { $result = ApplyFilter $result 'vhost' $VirtualHost }
 

--- a/Public/Get-RabbitMQConnection.ps1
+++ b/Public/Get-RabbitMQConnection.ps1
@@ -42,7 +42,7 @@
    You can pipe Name to filter the results.
 
 .OUTPUTS
-   By default, the cmdlet returns list of RabbitMQ.Connection objects which describe connections. 
+   By default, the cmdlet returns list of RabbitMQ.Connection objects which describe connections.
 
 .LINK
     https://www.rabbitmq.com/management.html - information about RabbitMQ management plugin.
@@ -56,7 +56,7 @@ function Get-RabbitMQConnection
         [parameter(ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
         [Alias("Connection", "ConnectionName")]
         [string[]]$Name = "",
-               
+
         # Name of the computer hosting RabbitMQ server. Defalut value is localhost.
         [parameter(ValueFromPipelineByPropertyName=$true)]
         [Alias("HostName", "hn", "cn")]
@@ -64,7 +64,11 @@ function Get-RabbitMQConnection
 
         # Credentials to use when logging to RabbitMQ server.
         [Parameter(Mandatory=$false)]
-        [PSCredential]$Credentials = $defaultCredentials
+        [PSCredential]$Credentials = $defaultCredentials,
+
+        # Disable certificate check
+        [Parameter(Mandatory=$false)]
+        [switch]${SkipCertificateCheck}
     )
 
     Begin
@@ -74,8 +78,8 @@ function Get-RabbitMQConnection
     {
         if ($pscmdlet.ShouldProcess("server $BaseUri", "Get connection(s): $(NamesToString $Name '(all)')"))
         {
-            $result = GetItemsFromRabbitMQApi -BaseUri $BaseUri $Credentials "connections"
-            
+            $result = GetItemsFromRabbitMQApi -BaseUri $BaseUri $Credentials "connections" -SkipCertificateCheck:$SkipCertificateCheck
+
             $result = ApplyFilter $result 'name' $Name
 
             $result | Add-Member -NotePropertyName "HostName" -NotePropertyValue $BaseUri

--- a/Public/Get-RabbitMQExchange.ps1
+++ b/Public/Get-RabbitMQExchange.ps1
@@ -37,7 +37,7 @@
 
    This command gets a list of all Virtual Hosts which name starts with "private" or "public".
 
-.EXAMPLE 
+.EXAMPLE
     Get-RabbitMQVirtualHost marketing_private | select *
 
     This command selects all properties for given Virtual Host.
@@ -51,7 +51,7 @@
    You can pipe Virtual Host names to filter results.
 
 .OUTPUTS
-   By default, the cmdlet returns list of RabbitMQ.VirtualHost objects which describe Virtual Hosts. 
+   By default, the cmdlet returns list of RabbitMQ.VirtualHost objects which describe Virtual Hosts.
 
 .LINK
     https://www.rabbitmq.com/management.html - information about RabbitMQ management plugin.
@@ -70,7 +70,7 @@ function Get-RabbitMQExchange
         [parameter(ValueFromPipelineByPropertyName=$true)]
         [Alias("vh")]
         [string]$VirtualHost = "",
-        
+
         # Name of the computer hosting RabbitMQ server. Defalut value is localhost.
         [parameter(ValueFromPipelineByPropertyName=$true)]
         [Alias("HostName", "hn", "cn")]
@@ -78,7 +78,11 @@ function Get-RabbitMQExchange
 
         # Credentials to use when logging to RabbitMQ server.
         [Parameter(Mandatory=$false)]
-        [PSCredential]$Credentials = $defaultCredentials
+        [PSCredential]$Credentials = $defaultCredentials,
+
+        # Disable certificate check
+        [Parameter(Mandatory=$false)]
+        [switch]${SkipCertificateCheck}
     )
 
     Begin
@@ -88,8 +92,8 @@ function Get-RabbitMQExchange
     {
         if ($pscmdlet.ShouldProcess("server $BaseUri", "Get exchange(s): $(NamesToString $Name '(all)')"))
         {
-            $exchanges = GetItemsFromRabbitMQApi -BaseUri $BaseUri $Credentials "exchanges"
-            
+            $exchanges = GetItemsFromRabbitMQApi -BaseUri $BaseUri $Credentials "exchanges" -SkipCertificateCheck:$SkipCertificateCheck
+
             $result = ApplyFilter $exchanges 'vhost' $VirtualHost
             $result = ApplyFilter $result 'name' $Name
 

--- a/Public/Get-RabbitMQMessage.ps1
+++ b/Public/Get-RabbitMQMessage.ps1
@@ -29,7 +29,7 @@
 .INPUTS
 
 .OUTPUTS
-   By default, the cmdlet returns list of RabbitMQ.QueueMessage objects which describe connections. 
+   By default, the cmdlet returns list of RabbitMQ.QueueMessage objects which describe connections.
 
 .LINK
     https://www.rabbitmq.com/management.html - information about RabbitMQ management plugin.
@@ -48,7 +48,7 @@ function Get-RabbitMQMessage
         [parameter(ValueFromPipelineByPropertyName=$true)]
         [Alias("vh", "vhost")]
         [string]$VirtualHost,
-        
+
         # Name of the computer hosting RabbitMQ server. Defalut value is localhost.
         [parameter(ValueFromPipelineByPropertyName=$true)]
         [Alias("HostName", "hn", "cn")]
@@ -78,7 +78,11 @@ function Get-RabbitMQMessage
 
         # Credentials to use when logging to RabbitMQ server.
         [Parameter(Mandatory=$false)]
-        [PSCredential]$Credentials = $defaultCredentials
+        [PSCredential]$Credentials = $defaultCredentials,
+
+        # Disable certificate check
+        [Parameter(Mandatory=$false)]
+        [switch]${SkipCertificateCheck}
     )
 
     Begin
@@ -93,7 +97,7 @@ function Get-RabbitMQMessage
             $p = @{}
             $p.Add("Credentials", $Credentials)
             if ($BaseUri) { $p.Add("BaseUri", $BaseUri) }
-            
+
             $queues = Get-RabbitMQQueue @p | ? Name -eq $Name
 
             if (-not $queues) { return; }
@@ -128,7 +132,7 @@ function Get-RabbitMQMessage
 
             Write-Debug "body: $bodyJson"
 
-            $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Post -ContentType "application/json" -Body $bodyJson
+            $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -SkipCertificateCheck:$SkipCertificateCheck -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Post -ContentType "application/json" -Body $bodyJson
 
             $result | Add-Member -NotePropertyName "QueueName" -NotePropertyValue $Name
 
@@ -153,7 +157,7 @@ function Get-RabbitMQMessage
                     {
                         SendItemsToOutput $result "RabbitMQ.QueueMessage" | ft -View Details
                     }
-                    
+
                     Default { SendItemsToOutput $result "RabbitMQ.QueueMessage" }
                 }
             }

--- a/Public/Get-RabbitMQNode.ps1
+++ b/Public/Get-RabbitMQNode.ps1
@@ -56,7 +56,7 @@ function Get-RabbitMQNode
         [parameter(ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
         [Alias("Node", "NodeName")]
         [string[]]$Name = "",
-               
+
         # Name of the computer hosting RabbitMQ server. Defalut value is localhost.
         [parameter(ValueFromPipelineByPropertyName=$true)]
         [Alias("HostName", "hn", "cn")]
@@ -64,7 +64,11 @@ function Get-RabbitMQNode
 
         # Credentials to use when logging to RabbitMQ server.
         [Parameter(Mandatory=$false)]
-        [PSCredential]$Credentials = $defaultCredentials
+        [PSCredential]$Credentials = $defaultCredentials,
+
+        # Disable certificate check
+        [Parameter(Mandatory=$false)]
+        [switch]${SkipCertificateCheck}
     )
 
     Begin
@@ -74,8 +78,8 @@ function Get-RabbitMQNode
     {
         if ($pscmdlet.ShouldProcess("server $BaseUri", "Get node(s): $(NamesToString $Name '(all)')"))
         {
-            $result = GetItemsFromRabbitMQApi -BaseUri $BaseUri $Credentials "nodes"
-            
+            $result = GetItemsFromRabbitMQApi -BaseUri $BaseUri $Credentials "nodes" -SkipCertificateCheck:$SkipCertificateCheck
+
             $result = ApplyFilter $result 'name' $Name
 
             $result | Add-Member -NotePropertyName "HostName" -NotePropertyValue $BaseUri

--- a/Public/Get-RabbitMQOverview.ps1
+++ b/Public/Get-RabbitMQOverview.ps1
@@ -13,7 +13,7 @@
    You can pipe HostName to the cmdlet.
 
 .OUTPUTS
-   By default, the cmdlet returns list of RabbitMQ.ServerOverview objects which describe RabbitMQ server. 
+   By default, the cmdlet returns list of RabbitMQ.ServerOverview objects which describe RabbitMQ server.
 
 .EXAMPLE
    Get-RabbitMQOverview
@@ -45,7 +45,11 @@ function Get-RabbitMQOverview
 
         # Credentials to use when logging to RabbitMQ server.
         [Parameter(Mandatory=$false)]
-        [PSCredential]$Credentials = $defaultCredentials
+        [PSCredential]$Credentials = $defaultCredentials,
+
+        # Disable certificate check
+        [Parameter(Mandatory=$false)]
+        [switch]${SkipCertificateCheck}
     )
 
     Begin
@@ -64,7 +68,7 @@ function Get-RabbitMQOverview
 
         foreach ($cn in $BaseUri)
         {
-            $overview = GetItemsFromRabbitMQApi -BaseUri $cn $Credentials "overview"
+            $overview = GetItemsFromRabbitMQApi -BaseUri $cn $Credentials "overview" -SkipCertificateCheck:$SkipCertificateCheck
             $overview | Add-Member -NotePropertyName "HostName" -NotePropertyValue $cn
             $overview.PSObject.TypeNames.Insert(0, "RabbitMQ.ServerOverview")
 

--- a/Public/Get-RabbitMQPermission.ps1
+++ b/Public/Get-RabbitMQPermission.ps1
@@ -41,7 +41,7 @@
    You can pipe Virtual Host and User names to filter results.
 
 .OUTPUTS
-   By default, the cmdlet returns list of RabbitMQ.Permission objects. 
+   By default, the cmdlet returns list of RabbitMQ.Permission objects.
 
 .LINK
     https://www.rabbitmq.com/management.html - information about RabbitMQ management plugin.
@@ -67,7 +67,11 @@ function Get-RabbitMQPermission
 
         # Credentials to use when logging to RabbitMQ server.
         [Parameter(Mandatory=$false)]
-        [PSCredential]$Credentials = $defaultCredentials
+        [PSCredential]$Credentials = $defaultCredentials,
+
+        # Disable certificate check
+        [Parameter(Mandatory=$false)]
+        [switch]${SkipCertificateCheck}
     )
 
     Begin
@@ -77,7 +81,7 @@ function Get-RabbitMQPermission
     {
         if ($pscmdlet.ShouldProcess("server $BaseUri", "Get permission(s) for VirtualHost = $(NamesToString $VirtualHost '(all)') and User = $(NamesToString $User '(all)')"))
         {
-            $result = GetItemsFromRabbitMQApi -BaseUri $BaseUri $Credentials "permissions"
+            $result = GetItemsFromRabbitMQApi -BaseUri $BaseUri $Credentials "permissions" -SkipCertificateCheck:$SkipCertificateCheck
             $result = ApplyFilter $result "vhost" $VirtualHost
             $result = ApplyFilter $result "user" $User
 

--- a/Public/Get-RabbitMQQueueBinding.ps1
+++ b/Public/Get-RabbitMQQueueBinding.ps1
@@ -31,7 +31,7 @@
    You can pipe Name, VirtualHost and HostName to this cmdlet.
 
 .OUTPUTS
-   By default, the cmdlet returns list of RabbitMQ.QueueBinding objects which describe connections. 
+   By default, the cmdlet returns list of RabbitMQ.QueueBinding objects which describe connections.
 
 .LINK
     https://www.rabbitmq.com/management.html - information about RabbitMQ management plugin.
@@ -58,7 +58,11 @@ function Get-RabbitMQQueueBinding
 
         # Credentials to use when logging to RabbitMQ server.
         [Parameter(Mandatory=$false)]
-        [PSCredential]$Credentials = $defaultCredentials
+        [PSCredential]$Credentials = $defaultCredentials,
+
+        # Disable certificate check
+        [Parameter(Mandatory=$false)]
+        [switch]${SkipCertificateCheck}
     )
 
     Begin
@@ -72,7 +76,7 @@ function Get-RabbitMQQueueBinding
             $p = @{}
             $p.Add("Credentials", $Credentials)
             if ($BaseUri) { $p.Add("BaseUri", $BaseUri) }
-            
+
             $queues = Get-RabbitMQQueue @p | ? Name -eq $Name
 
             if (-not $queues) { return; }
@@ -91,7 +95,7 @@ function Get-RabbitMQQueueBinding
         {
             foreach ($n in $Name)
             {
-                $result = GetItemsFromRabbitMQApi -BaseUri $BaseUri $Credentials "queues/$([System.Web.HttpUtility]::UrlEncode($VirtualHost))/$([System.Web.HttpUtility]::UrlEncode($n))/bindings"
+                $result = GetItemsFromRabbitMQApi -BaseUri $BaseUri $Credentials "queues/$([System.Web.HttpUtility]::UrlEncode($VirtualHost))/$([System.Web.HttpUtility]::UrlEncode($n))/bindings" -SkipCertificateCheck:$SkipCertificateCheck
 
                 $result | Add-Member -NotePropertyName "HostName" -NotePropertyValue $BaseUri
 

--- a/Public/Get-RabbitMQUser.ps1
+++ b/Public/Get-RabbitMQUser.ps1
@@ -40,7 +40,7 @@
    You can pipe Names and HostNames to filter results.
 
 .OUTPUTS
-   By default, the cmdlet returns list of RabbitMQ.User objects which describe user. 
+   By default, the cmdlet returns list of RabbitMQ.User objects which describe user.
 
 .LINK
     https://www.rabbitmq.com/management.html - information about RabbitMQ management plugin.
@@ -58,12 +58,16 @@ function Get-RabbitMQUser
         [parameter(ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
         [Alias("cn", "HostName")]
         [string]$BaseUri = $defaultComputerName,
-        
+
         [ValidateSet("Default", "Flat")]
         [string]$View,
 
         [Parameter(Mandatory=$false)]
-        [PSCredential]$Credentials = $defaultCredentials
+        [PSCredential]$Credentials = $defaultCredentials,
+
+        # Disable certificate check
+        [Parameter(Mandatory=$false)]
+        [switch]${SkipCertificateCheck}
     )
 
     Begin
@@ -73,10 +77,10 @@ function Get-RabbitMQUser
     {
         if ($pscmdlet.ShouldProcess("server $BaseUri", "Get user(s)"))
         {
-            $result = GetItemsFromRabbitMQApi -BaseUri $BaseUri $Credentials "users"
+            $result = GetItemsFromRabbitMQApi -BaseUri $BaseUri $Credentials "users" -SkipCertificateCheck:$SkipCertificateCheck
             $result = ApplyFilter $result 'name' $Name
             $result | Add-Member -NotePropertyName "HostName" -NotePropertyValue $BaseUri
- 
+
             if (-not $View) { SendItemsToOutput $result "RabbitMQ.User" }
             else { SendItemsToOutput $result "RabbitMQ.User" | ft -View $View }
         }

--- a/Public/Get-RabbitMQVirtualHost.ps1
+++ b/Public/Get-RabbitMQVirtualHost.ps1
@@ -37,7 +37,7 @@
 
    This command gets a list of all Virtual Hosts which name starts with "private" or "public".
 
-.EXAMPLE 
+.EXAMPLE
     Get-RabbitMQVirtualHost marketing_private | select *
 
     This command selects all properties for given Virtual Host.
@@ -51,7 +51,7 @@
    You can pipe Virtual Host names to filter results.
 
 .OUTPUTS
-   By default, the cmdlet returns list of RabbitMQ.VirtualHost objects which describe Virtual Hosts. 
+   By default, the cmdlet returns list of RabbitMQ.VirtualHost objects which describe Virtual Hosts.
 
 .LINK
     https://www.rabbitmq.com/management.html - information about RabbitMQ management plugin.
@@ -73,7 +73,11 @@ function Get-RabbitMQVirtualHost
 
         # Credentials to use when logging to RabbitMQ server.
         [Parameter(Mandatory=$false)]
-        [PSCredential]$Credentials = $defaultCredentials
+        [PSCredential]$Credentials = $defaultCredentials,
+
+        # Disable certificate check
+        [Parameter(Mandatory=$false)]
+        [switch]${SkipCertificateCheck}
     )
 
     Begin
@@ -83,7 +87,7 @@ function Get-RabbitMQVirtualHost
     {
         if ($pscmdlet.ShouldProcess("server $BaseUri", "Get vhost(s): $(NamesToString $Name '(all)')"))
         {
-            $vhosts = GetItemsFromRabbitMQApi -BaseUri $BaseUri $Credentials "vhosts"
+            $vhosts = GetItemsFromRabbitMQApi -BaseUri $BaseUri $Credentials "vhosts" -SkipCertificateCheck:$SkipCertificateCheck
             $result = ApplyFilter $vhosts "name" $Name
 
             foreach($i in $result)

--- a/Public/Remove-RabbitMQConnection.ps1
+++ b/Public/Remove-RabbitMQConnection.ps1
@@ -42,7 +42,7 @@
    $a | Remove-RabbitMQConnection
 
    Above example shows how to pipe both connection name and Computer Name to specify server.
-   
+
    The above example will close two connection named "c1" and "c2" to local server, and one connection named "c3" to the server 127.0.0.1.
 
 .INPUTS
@@ -68,7 +68,11 @@ function Remove-RabbitMQConnection
 
         # Credentials to use when logging to RabbitMQ server.
         [Parameter(Mandatory=$false)]
-        [PSCredential]$Credentials = $defaultCredentials
+        [PSCredential]$Credentials = $defaultCredentials,
+
+        # Disable certificate check
+        [Parameter(Mandatory=$false)]
+        [switch]${SkipCertificateCheck}
     )
 
     Begin
@@ -79,7 +83,7 @@ function Remove-RabbitMQConnection
     {
         if (-not $pscmdlet.ShouldProcess("server: $BaseUri", "Close connection(s): $(NamesToString $Name '(all)')")) {
             foreach ($qn in $Name)
-            { 
+            {
                 Write "Closing connection $qn to server=$BaseUri"
                 $cnt++
             }
@@ -89,8 +93,7 @@ function Remove-RabbitMQConnection
         foreach($n in $Name)
         {
             $url = Join-Parts $BaseUri "/api/connections/$([System.Web.HttpUtility]::UrlEncode($n))"
-            $result = Invoke-RestMethod $url -Credential $Credentials -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Delete
-
+            $result = Invoke-RestMethod $url -Credential $Credentials -SkipCertificateCheck:$SkipCertificateCheck -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Delete
             Write-Verbose "Closed connection $n to server $BaseUri"
             $cnt++
         }

--- a/Public/Remove-RabbitMQExchange.ps1
+++ b/Public/Remove-RabbitMQExchange.ps1
@@ -44,7 +44,7 @@
    $a | Remove-RabbitMQExchange
 
    Above example shows how to pipe both Exchange name and Computer Name to specify server from which the Exchange should be removed.
-   
+
    In the above example two Exchanges named "e1" and "e2" will be removed from RabbitMQ local server, and one Exchange named "e3" will be removed from the server 127.0.0.1.
 
 .INPUTS
@@ -75,7 +75,11 @@ function Remove-RabbitMQExchange
 
         # Credentials to use when logging to RabbitMQ server.
         [Parameter(Mandatory=$false)]
-        [PSCredential]$Credentials = $defaultCredentials
+        [PSCredential]$Credentials = $defaultCredentials,
+
+        # Disable certificate check
+        [Parameter(Mandatory=$false)]
+        [switch]${SkipCertificateCheck}
     )
 
     Begin
@@ -89,8 +93,8 @@ function Remove-RabbitMQExchange
             foreach($n in $Name)
             {
                 $url = Join-Parts $BaseUri "/api/exchanges/$([System.Web.HttpUtility]::UrlEncode($VirtualHost))/$([System.Web.HttpUtility]::UrlEncode($n))"
-        
-                $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Delete
+
+                $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -SkipCertificateCheck:$SkipCertificateCheck -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Delete
 
                 Write-Verbose "Deleted Exchange $n on server $BaseUri, Virtual Host $VirtualHost"
                 $cnt++

--- a/Public/Remove-RabbitMQPermission.ps1
+++ b/Public/Remove-RabbitMQPermission.ps1
@@ -48,14 +48,18 @@ function Remove-RabbitMQPermission
 
         # Credentials to use when logging to RabbitMQ server.
         [Parameter(Mandatory=$false)]
-        [PSCredential]$Credentials = $defaultCredentials
+        [PSCredential]$Credentials = $defaultCredentials,
+
+        # Disable certificate check
+        [Parameter(Mandatory=$false)]
+        [switch]${SkipCertificateCheck}
     )
 
     Begin
-    {        
+    {
         $p = Get-RabbitMQPermission -BaseUri $BaseUri -Credentials $Credentials -VirtualHost $VirtualHost -User $User
         if (-not $p) { throw "Permissions to virtual host $VirtualHost for user $User do not exist. To create permissions use Add-RabbitMQPermission cmdlet." }
-        
+
         $cnt = 0
     }
     Process
@@ -63,7 +67,7 @@ function Remove-RabbitMQPermission
         if ($pscmdlet.ShouldProcess("server: $BaseUri", "Remove permissions to virtual host $VirtualHost for user $User : $Configure, $Read $Write"))
         {
             $url = Join-Parts $BaseUri "/api/permissions/$([System.Web.HttpUtility]::UrlEncode($VirtualHost))/$([System.Web.HttpUtility]::UrlEncode($User))"
-            $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Delete
+            $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -SkipCertificateCheck:$SkipCertificateCheck -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Delete
 
             Write-Verbose "Removed permissions to $VirtualHost for $User : $Configure, $Read, $Write"
             $cnt++

--- a/Public/Remove-RabbitMQQueue.ps1
+++ b/Public/Remove-RabbitMQQueue.ps1
@@ -44,7 +44,7 @@
    $a | Remove-RabbitMQQueue
 
    Above example shows how to pipe both Exchange name and Computer Name to specify server from which the Exchange should be removed.
-   
+
    In the above example two Exchanges named "e1" and "e2" will be removed from RabbitMQ local server, and one Exchange named "e3" will be removed from the server 127.0.0.1.
 
 .INPUTS
@@ -75,7 +75,11 @@ function Remove-RabbitMQQueue
 
         # Credentials to use when logging to RabbitMQ server.
         [Parameter(Mandatory=$false)]
-        [PSCredential]$Credentials = $defaultCredentials
+        [PSCredential]$Credentials = $defaultCredentials,
+
+        # Disable certificate check
+        [Parameter(Mandatory=$false)]
+        [switch]${SkipCertificateCheck}
     )
 
     Begin
@@ -90,8 +94,8 @@ function Remove-RabbitMQQueue
             {
                 $url = Join-Parts $BaseUri "/api/queues/$([System.Web.HttpUtility]::UrlEncode($VirtualHost))/$([System.Web.HttpUtility]::UrlEncode($n))"
                 Write-Verbose "Invoking REST API: $url"
-        
-                $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Delete
+
+                $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -SkipCertificateCheck:$SkipCertificateCheck -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Delete
 
                 Write-Verbose "Deleted Queue $n on server $BaseUri, Virtual Host $VirtualHost"
                 $cnt++

--- a/Public/Remove-RabbitMQQueueBinding.ps1
+++ b/Public/Remove-RabbitMQQueueBinding.ps1
@@ -67,7 +67,11 @@ function Remove-RabbitMQQueueBinding
 
         # Credentials to use when logging to RabbitMQ server.
         [Parameter(Mandatory=$false)]
-        [PSCredential]$Credentials = $defaultCredentials
+        [PSCredential]$Credentials = $defaultCredentials,
+
+        # Disable certificate check
+        [Parameter(Mandatory=$false)]
+        [switch]${SkipCertificateCheck}
     )
 
     Begin
@@ -81,8 +85,8 @@ function Remove-RabbitMQQueueBinding
         {
             $url = Join-Parts $BaseUri "/api/bindings/$([System.Web.HttpUtility]::UrlEncode($VirtualHost))/e/$([System.Web.HttpUtility]::UrlEncode($ExchangeName))/q/$([System.Web.HttpUtility]::UrlEncode($Name))/$([System.Web.HttpUtility]::UrlEncode($RoutingKey))"
             Write-Verbose "Invoking REST API: $url"
-        
-            $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Delete
+
+            $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -SkipCertificateCheck:$SkipCertificateCheck -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Delete
 
             Write-Verbose "Removed binding between exchange $ExchangeName and queue $Name $n on $BaseUri/$VirtualHost"
             $cnt++

--- a/Public/Remove-RabbitMQUser.ps1
+++ b/Public/Remove-RabbitMQUser.ps1
@@ -43,7 +43,11 @@ function Remove-RabbitMQUser
 
         # Credentials to use when logging to RabbitMQ server.
         [Parameter(Mandatory=$false)]
-        [PSCredential]$Credentials = $defaultCredentials
+        [PSCredential]$Credentials = $defaultCredentials,
+
+        # Disable certificate check
+        [Parameter(Mandatory=$false)]
+        [switch]${SkipCertificateCheck}
     )
 
     Begin
@@ -55,7 +59,7 @@ function Remove-RabbitMQUser
         if ($pscmdlet.ShouldProcess("server: $BaseUri", "Delete user $Name"))
         {
             $url = Join-Parts $BaseUri "/api/users/$([System.Web.HttpUtility]::UrlEncode($Name))"
-            $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Delete -ContentType "application/json"
+            $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -SkipCertificateCheck:$SkipCertificateCheck -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Delete -ContentType "application/json"
 
             Write-Verbose "Deleted user $User"
             $cnt++

--- a/Public/Remove-RabbitMQVirtualHost.ps1
+++ b/Public/Remove-RabbitMQVirtualHost.ps1
@@ -44,7 +44,7 @@
    $a | Remove-RabbitMQVirtualHost
 
    Above example shows how to pipe both Virtual Host name and Computer Name to specify server from which the Virtual Host should be removed.
-   
+
    In the above example two Virtual Hosts named "vh1" and "vh2" will be removed from RabbitMQ local server, and one Virtual Host named "vh3" will be removed from the server 127.0.0.1.
 
 .INPUTS
@@ -70,7 +70,11 @@ function Remove-RabbitMQVirtualHost
 
         # Credentials to use when logging to RabbitMQ server.
         [Parameter(Mandatory=$false)]
-        [PSCredential]$Credentials = $defaultCredentials
+        [PSCredential]$Credentials = $defaultCredentials,
+
+        # Disable certificate check
+        [Parameter(Mandatory=$false)]
+        [switch]${SkipCertificateCheck}
     )
 
     Begin
@@ -81,8 +85,8 @@ function Remove-RabbitMQVirtualHost
     {
         if (-not $pscmdlet.ShouldProcess("server: $BaseUri", "Remove vhost(s): $(NamesToString $Name '(all)')")) {
             foreach ($qn in $Name)
-            { 
-                Write "Deleting Virtual Host(s) $qn (server=$BaseUri)" 
+            {
+                Write "Deleting Virtual Host(s) $qn (server=$BaseUri)"
                 $cnt++
             }
             return
@@ -91,7 +95,7 @@ function Remove-RabbitMQVirtualHost
         foreach($n in $Name)
         {
             $url = Join-Parts $BaseUri "/api/vhosts/$([System.Web.HttpUtility]::UrlEncode($n))"
-            $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Delete -ContentType "application/json"
+            $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -SkipCertificateCheck:$SkipCertificateCheck -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Delete -ContentType "application/json"
 
             Write-Verbose "Removed Virtual Host $n on server $BaseUri"
             $cnt++

--- a/Public/Set-RabbitMQPermission.ps1
+++ b/Public/Set-RabbitMQPermission.ps1
@@ -60,14 +60,18 @@ function Set-RabbitMQPermission
 
         # Credentials to use when logging to RabbitMQ server.
         [Parameter(Mandatory=$false)]
-        [PSCredential]$Credentials = $defaultCredentials
+        [PSCredential]$Credentials = $defaultCredentials,
+
+        # Disable certificate check
+        [Parameter(Mandatory=$false)]
+        [switch]${SkipCertificateCheck}
     )
 
     Begin
-    {        
+    {
         $p = Get-RabbitMQPermission -BaseUri $BaseUri -Credentials $Credentials -VirtualHost $VirtualHost -User $User
         if (-not $p) { throw "Permissions to virtual host $VirtualHost for user $User do not exist. To create permissions use Add-RabbitMQPermission cmdlet." }
-        
+
         $cnt = 0
     }
     Process
@@ -78,9 +82,9 @@ function Set-RabbitMQPermission
             $body = @{
                 'configure' = $Configure
                 'read' = $Read
-                'write' = $Write                
+                'write' = $Write
             } | ConvertTo-Json
-            $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Put -ContentType "application/json" -Body $body
+            $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -SkipCertificateCheck:$SkipCertificateCheck -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Put -ContentType "application/json" -Body $body
 
             Write-Verbose "Changed permission to $VirtualHost for $User : $Configure, $Read, $Write"
             $cnt++

--- a/Public/Set-RabbitMQUser.ps1
+++ b/Public/Set-RabbitMQUser.ps1
@@ -50,17 +50,21 @@ function Set-RabbitMQUser
         [parameter(ValueFromPipelineByPropertyName=$true)]
         [Alias("HostName", "hn", "cn")]
         [string]$BaseUri = $defaultComputerName,
-        
+
         # Credentials to use when logging to RabbitMQ server.
         [Parameter(Mandatory=$false)]
-        [PSCredential]$Credentials = $defaultCredentials
+        [PSCredential]$Credentials = $defaultCredentials,
+
+        # Disable certificate check
+        [Parameter(Mandatory=$false)]
+        [switch]${SkipCertificateCheck}
     )
 
     Begin
-    {       
+    {
         $user = Get-RabbitMQUser -Credentials $Credentials -BaseUri $BaseUri -Name $Name
         if (-not $user) { throw "User $Name doesn't exist in server $BaseUri" }
-        
+
         $cnt = 0
     }
     Process
@@ -73,7 +77,7 @@ function Set-RabbitMQUser
             if ($NewPassword) { $body.Add("password", $NewPassword) }
             if ($Tag) { $body.Add("tags", $Tag -join ',') } else { $body.Add("tags", $user.tags) }
             $bodyJson = $body | ConvertTo-Json
-            $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Put -ContentType "application/json" -Body $bodyJson
+            $result = Invoke-RestMethod $url -Credential $Credentials -AllowEscapedDotsAndSlashes -SkipCertificateCheck:$SkipCertificateCheck -DisableKeepAlive:$InvokeRestMethodKeepAlive -ErrorAction Continue -Method Put -ContentType "application/json" -Body $bodyJson
 
             Write-Verbose "Update user $User"
             $cnt++


### PR DESCRIPTION
Hi, 

based on issue #45 i added the option "SkipCertificateCheck" to all functions. I hope it's all fine, i am not the god-mode-powersheller. Let me know if something must changed. 
I tested it against a RabbitMQ instance with Version 3.9.1. with the alpine-management container. The self-signed certicates are created with openssl. 

SSLSUBJECT="/C=$CRT_C/ST=$CRT_S/L=$CRT_L/O=$CRT_OU/CN=$CRT_CN"
openssl req -x509 -newkey rsa:${CRT_LENGTH} -keyout /home/appuser/data/certificates/key.key -out /home/appuser/data/certificates/cer.crt -days $CRT_VALIDITY -nodes -subj "$SSLSUBJECT"

